### PR TITLE
Trivial typofixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 [![Build Status](https://github.com/google/vimscript-language-server/workflows/Rust/badge.svg)](https://github.com/google/vimscript-language-server/actions)
 
-# Vimscript Language Server
+# Vim script Language Server
 
-Implementation of Language Server protocol for vimscript / vimL language in
+Implementation of Language Server protocol for Vim script / vimL language in
 Rust.
 
 This project is still in very early development stage - it does not support all
-of vimscript syntax and most features are not implemented yet.
+of Vim script syntax and most features are not implemented yet.
 
-The long term goal is to implement vimscript AST that will allow for:
+The long term goal is to implement Vim script AST that will allow for:
 
 * building language server
-* building vimscript formatter, that vim plugins could use in CI
+* building Vim script formatter, that vim plugins could use in CI
 * building linter, that vim plugin could use in CI
 
 The next steps:
@@ -19,7 +19,7 @@ The next steps:
 * perform additional analysis on AST (e.g. variable tracking), to allow for features like renaming,
 * build a foundation for formatter,
 * build a foundation for generic linter (so that custom checks can be added),
-* support all syntax of vimscript.
+* support all syntax of Vim script.
 
 ## Setup
 


### PR DESCRIPTION
* See `:h` and you can confirm Vim is only using the term "Vim script"
  in the docs.
    * Some options/documentation indices sometimes abbreviate,
      but they aren't used in sentences.